### PR TITLE
Set name in Vagrantfile to get better CLI output

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,8 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "micropcf/base"
   config.vm.box_version = "0"
-
+  config.vm.define "micropcf" do |micropcf|
+  end
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   provider_is_aws = (!ARGV.nil? && ARGV.join(' ').match(/provider(=|\s+)aws/))


### PR DESCRIPTION
Sets the name of the box to 'micropcf' so that when you do a vagrant destroy or similar you get:

```
micropcf: Are you sure you want to destroy the 'micropcf' VM? [y/N] y
```

instead of 

```
    default: Are you sure you want to destroy the 'default' VM? [y/N] y
```

Fixes #7